### PR TITLE
PID-Regler von patkan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,26 @@
 OpenSoldering
 =============
 
-Kurzbeschreibung:
+###Kurzbeschreibung
 OpenSource Lötstation mit (hoffentlich mal) Unterstützung für verschiedene JBC-, Weller- und Ersa-Lötkolben
 
 
-Aufbau:
+###Aufbau
 Modular. Kommunikation über RS485 mit dem SB9-Bussystem
 
-Ziel:
+###Ziel
 eine OpenSource Lötstation mit Basisstation und einzelnen Satellitenstationen, die jeweils ein Lötgerät (Kolben, Zange, Pinzette) ansteuern. Auch geeignet für Gruppen oder Werkstätten, die mehrere Lötplätze brauchen.
 
 
-Status Quo:
--Modul für den JBC-Lötkolben T245A in Entwicklung.
--Thermospannung im Arbeitspunkt für C245 Kartusche 4,2mV; Aufnahme der Kennlinie fehlt noch.
+###Status Quo
+- Modul für den JBC-Lötkolben T245A in Entwicklung.
+- Thermospannung im Arbeitspunkt für C245 Kartusche 4,2mV; Aufnahme der Kennlinie fehlt noch.
 
-TODOs:
+###TODOs
 - Aufbau und ausführliche Tests am Lötkolben, Programmierung der PI-Regelung mit Vorsteuerung, (vermutlich kein PID-Konzept nötig) und Bau der Kontrollstation.
 - Planung für ein Weller-Modul für die modernen Lötspitzen des WXMP-Lötkolbens, die einen einfachen und günstigen Lötkolben versprechen.
 - Planung der Kontrollstation:
-	=> Display: OLED? gLCD?
-	=> Eingabe: Drehknopf? Touchscreen?
-	=> zusätzliche Konnektivität: IoT? Bluetooth? Lötrauchabsaugung?
-	=> Reglerprofile: Optimierung auf Ausregelzeit/minimale Überschwingung?
+	* Display: OLED? gLCD?
+	* Eingabe: Drehknopf? Touchscreen?
+	* zusätzliche Konnektivität: IoT? Bluetooth? Lötrauchabsaugung?
+	* Reglerprofile: Optimierung auf Ausregelzeit/minimale Überschwingung?

--- a/loetkolbenmodul.c
+++ b/loetkolbenmodul.c
@@ -78,19 +78,6 @@ ISR (TIMER0_OVF_vect, ISR_BLOCK) {
 	*/
 
 
-	// static float  yk = 0, yk1 = 0; // letzter Reglerausgangswert
-	// uint16_t ek = spitzentemp, ek1;
-	//
-	// Regler (Konzept: PD)
-	// yk = yk1 + (kr * (ek - ek1 + (t / tn) * ek1));
-	// yk1 = yk;
-	// ek1 = ek; // sichere letzten Tempwert
-
-
-
-	//das oben ist die alte Implementierung mit Kommentaren, jetzt erstmal eine
-	//neue, dann schauen, ob sich noch etwas recyclen lässt.
-
 	//TODO: dies ist der neue Aufruf für die externe PID-Funktion
 	//float yk;
 	//yk = pid_compute(spitzentemp, solltemperatur);

--- a/loetkolbenmodul.c
+++ b/loetkolbenmodul.c
@@ -26,6 +26,7 @@
 
 #include "definitionen.h"
 #include "pid.c"
+extern volatile float kp, ki, kd; //TODO --> das hier soll noch weg
 
 
 void setKolbenPower (float sollwert) {
@@ -38,7 +39,7 @@ volatile float leistung = 0, rawtemp = 0, spitzentemp = 0;
 volatile uint16_t heizstrom = 0, eingangsspannung = 0; // U in mV, I in mA
 volatile uint16_t solltemperatur = 0, platinentemperatur = 0;
 
-volatile float ki = 1, kp = 1;
+//volatile float ki = 1, kp = 1, kd = 1; // werden bereits in pid.c deklariert --> Zugriff sollte am besten nur über setTunings erfolgen
 
 ISR (TIMER0_OVF_vect, ISR_BLOCK) {
 	ADMUX = ADMUX & 0b11100000; // lösche selektiv die MUX-Bits

--- a/loetkolbenmodul.c
+++ b/loetkolbenmodul.c
@@ -97,6 +97,7 @@ ISR (TIMER0_OVF_vect, ISR_BLOCK) {
 	//das oben ist die alte Implementierung mit Kommentaren, jetzt erstmal eine
 	//neue, dann schauen, ob sich noch etwas recyclen lässt.
 
+	float yk;
 	yk = pid_compute(spitzentemp, solltemperatur);
 
 

--- a/pid.c
+++ b/pid.c
@@ -1,0 +1,113 @@
+/*
+ *    Filename: pid.c
+ *     Version: 0.0.4
+ * Description: PID controller for the soldering module
+ *     License: GPLv3 or later
+ *     Depends:
+ *
+ *      Author: Patrick Kanzler, adaption of code by Brett Beauregard
+ *        Date: 2014-12-30
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+
+
+//TODO Variablenformate sind noch vollkommen durcheinander und müssen optimiert werden
+
+  #define SAMPLETIME_US 4080
+  #define COMPUTE_EVERY_NTH_CYCLE 1
+  volatile uint8_t cycle_count = 0;
+
+  float outMin, outMax;
+
+
+  /*working variables*/
+  double ITerm, lastInput;
+  double kp, ki, kd;
+  int SampleTime = 1000; //1 sec
+
+  float output = 0;
+
+
+
+  float pid_compute(uint16_t input, uint16_t setpoint)
+  {
+
+
+
+    cycle_count++;
+    if(cycle_count == COMPUTE_EVERY_NTH_CYCLE)
+    {
+      //compute new output value
+
+      /*Compute all the working error variables*/
+      double error = setpoint - input;
+      ITerm+= (ki * error);
+      if(ITerm > outMax) ITerm = outMax;
+      else if(ITerm < outMin) ITerm = outMin;
+      double dInput = (input - lastInput);
+
+      /*Compute PID Output*/
+      output = kp * error + ITerm - kd * dInput;
+      if(output > outMax) output = outMax;
+      else if(output < outMin) output = outMin;
+
+      /*Remember some variables for next time*/
+      lastInput = input;
+
+    } else if (cycle_count >= COMPUTE_EVERY_NTH_CYCLE)
+    {
+      //skip this cycle, take old value
+      cycle_count = 0;
+    }
+
+    return output;
+  }
+
+  uint8_t pid_SetTunings(double Kp, double Ki, double Kd)
+  {
+    if (Kp<0 || Ki<0|| Kd<0) return 1;
+
+      double SampleTimeInSec = ((double)SAMPLETIME_US)/1000000;
+      kp = Kp;
+      ki = Ki * SampleTimeInSec;
+      kd = Kd / SampleTimeInSec;
+
+      return 0;
+      }
+
+  uint8_t SetOutputLimits(float Min, float Max)
+  {
+    if(Min > Max) return 1;
+    outMin = Min;
+    outMax = Max;
+
+    if(output > outMax) output = outMax;
+    else if(output < outMin) output = outMin;
+
+    if(ITerm > outMax) ITerm= outMax;
+    else if(ITerm < outMin) ITerm= outMin;
+    return 0;
+  }
+
+
+          // uint8_t Initialize()
+          // {
+          //   lastInput = input;
+          //   ITerm = Output;
+          //   if(ITerm > outMax) ITerm= outMax;
+          //   else if(ITerm < outMin) ITerm= outMin;
+          // }

--- a/pid.c
+++ b/pid.c
@@ -36,7 +36,7 @@
 
   /*working variables*/
   double ITerm, lastInput;
-  double kp, ki, kd;
+  volatile float kp, ki, kd; //diese Variablen werden in loetkolbenmodul.c auch gebraucht --> TODO so anpassen, dass nur noch die Funktionen zur Anpassung genommen werden
   int SampleTime = 1000; //1 sec
 
   float output = 0;


### PR DESCRIPTION
Hi,
lies mal bitte die Änderungen durch. Im Moment ist der PID-Regler noch recht schlampig, was die Effizienz und Variablen angeht. Das muss auf jeden Fall noch verbessert werden. Außerdem muss man noch schauen, ob die pid.c nicht doch mit in die loetkolbenmodul.c soll.
Wenn da alles passt, dann kann man pid.c einfach durch auskommentieren verwenden.
Gruß
Patrick
